### PR TITLE
Add setContentView(int). Fix #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         applicationId "me.drakeet.mddemo"

--- a/demo/src/main/java/me/drakeet/mddemo/MyActivity.java
+++ b/demo/src/main/java/me/drakeet/mddemo/MyActivity.java
@@ -56,11 +56,11 @@ public class MyActivity extends ActionBarActivity {
                     }
                 )
                 .setNegativeButton(
-                    "CANCLE", new View.OnClickListener() {
+                    "CANCEL", new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
                             mMaterialDialog.dismiss();
-                            Toast.makeText(MyActivity.this, "Cancle", Toast.LENGTH_LONG).show();
+                            Toast.makeText(MyActivity.this, "Cancel", Toast.LENGTH_LONG).show();
                         }
                     }
                 )
@@ -168,6 +168,22 @@ public class MyActivity extends ActionBarActivity {
                         }
                     );
 
+                alert.show();
+                break;
+            }
+            case R.id.button_set_contentViewById: {
+                final MaterialDialog alert = new MaterialDialog(this)
+                        .setTitle("MaterialDialog")
+                        .setContentView(R.layout.custom_message_content);
+
+                alert.setPositiveButton(
+                        "OK", new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                alert.dismiss();
+                            }
+                        }
+                );
                 alert.show();
                 break;
             }

--- a/demo/src/main/res/layout/activity_my.xml
+++ b/demo/src/main/res/layout/activity_my.xml
@@ -48,6 +48,16 @@
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:text="setContentView (by id)"
+        android:id="@+id/button_set_contentViewById"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:onClick="setView"
+        android:layout_gravity="center_horizontal"/>
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:text="setBackground"
         android:id="@+id/button_set_background"
         android:layout_marginRight="16dp"

--- a/demo/src/main/res/layout/custom_message_content.xml
+++ b/demo/src/main/res/layout/custom_message_content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <AnalogClock
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/analogClock"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"/>
+
+</RelativeLayout>

--- a/library/src/main/java/me/drakeet/materialdialog/MaterialDialog.java
+++ b/library/src/main/java/me/drakeet/materialdialog/MaterialDialog.java
@@ -48,6 +48,7 @@ public class MaterialDialog {
     private Drawable                          mBackgroundDrawable;
     private int                               mBackgroundResId;
     private View                              mMessageContentView;
+    private int                               mMessageContentViewResId;
     private DialogInterface.OnDismissListener mOnDismissListener;
 
     public MaterialDialog(Context context) {
@@ -72,8 +73,23 @@ public class MaterialDialog {
 
     public MaterialDialog setContentView(View view) {
         mMessageContentView = view;
+        mMessageContentViewResId = 0;
         if (mBuilder != null) {
             mBuilder.setContentView(mMessageContentView);
+        }
+        return this;
+    }
+
+    /**
+     * Set a custom view resource to be the contents of the dialog.
+     *
+     * @param layoutResId resource ID to be inflated
+     */
+    public MaterialDialog setContentView(int layoutResId) {
+        mMessageContentViewResId = layoutResId;
+        mMessageContentView = null;
+        if (mBuilder != null) {
+            mBuilder.setContentView(layoutResId);
         }
         return this;
     }
@@ -248,6 +264,7 @@ public class MaterialDialog {
     private class Builder {
 
         private TextView     mTitleView;
+        private ViewGroup    mMessageContentRoot;
         private TextView     mMessageView;
         private Window       mAlertDialogWindow;
         private LinearLayout mButtonLayout;
@@ -279,6 +296,7 @@ public class MaterialDialog {
             );
 
             mTitleView = (TextView) mAlertDialogWindow.findViewById(R.id.title);
+            mMessageContentRoot = (ViewGroup) mAlertDialogWindow.findViewById(R.id.message_content_root);
             mMessageView = (TextView) mAlertDialogWindow.findViewById(R.id.message);
             mButtonLayout = (LinearLayout) mAlertDialogWindow.findViewById(R.id.buttonLayout);
             if (mView != null) {
@@ -325,6 +343,8 @@ public class MaterialDialog {
 
             if (mMessageContentView != null) {
                 this.setContentView(mMessageContentView);
+            } else if (mMessageContentViewResId != 0) {
+                this.setContentView(mMessageContentViewResId);
             }
             mAlertDialog.setCanceledOnTouchOutside(mCancel);
             if (mOnDismissListener != null) {
@@ -341,11 +361,15 @@ public class MaterialDialog {
         }
 
         public void setMessage(int resId) {
-            mMessageView.setText(resId);
+            if (mMessageView != null) {
+                mMessageView.setText(resId);
+            }
         }
 
         public void setMessage(CharSequence message) {
-            mMessageView.setText(message);
+            if (mMessageView != null) {
+                mMessageView.setText(message);
+            }
         }
 
         /**
@@ -464,6 +488,19 @@ public class MaterialDialog {
             }
         }
 
+        /**
+         * Set a custom view resource to be the contents of the dialog. The
+         * resource will be inflated into a ScrollView.
+         *
+         * @param layoutResId resource ID to be inflated
+         */
+        public void setContentView(int layoutResId) {
+            mMessageContentRoot.removeAllViews();
+            // Not setting this to the other content view because user has defined their own
+            // layout params, and we don't want to overwrite those.
+            LayoutInflater.from(mMessageContentRoot.getContext()).inflate(layoutResId, mMessageContentRoot);
+        }
+
         public void setBackground(Drawable drawable) {
             LinearLayout linearLayout = (LinearLayout) mAlertDialogWindow.findViewById(R.id.material_background);
             linearLayout.setBackground(drawable);
@@ -479,7 +516,6 @@ public class MaterialDialog {
             mAlertDialog.setCanceledOnTouchOutside(canceledOnTouchOutside);
         }
     }
-<<<<<<< HEAD
 
     /**
      * 动态测量listview-Item的高度
@@ -505,6 +541,3 @@ public class MaterialDialog {
     }
 
 }
-=======
-}
->>>>>>> origin/master

--- a/library/src/main/res/layout/layout_materialdialog.xml
+++ b/library/src/main/res/layout/layout_materialdialog.xml
@@ -33,7 +33,9 @@
                 android:layout_marginRight="24dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
+
             <ScrollView
+                android:id="@+id/message_content_root"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"


### PR DESCRIPTION
A new method for `MaterialDialog.setContentView(int layoutResId)` has been created so that users can set the custom view for just the message part. Also, the demo app gradle buildToolsVersion was increased to match the library buildToolsVersion, which fixed another bug not allowing the project to build.